### PR TITLE
Hotfix/add missing encoding

### DIFF
--- a/retrofire/RemoteBase.swift
+++ b/retrofire/RemoteBase.swift
@@ -83,11 +83,20 @@ open class RemoteBase {
     /// - parameter request: The request object to be used on Alamofire.request.
     ///
     /// - returns: Return a Call<[ResponseObject]> with the list of result objects based on ResponseObject or ErrorResponse (if Alamofire gets failures) inside the Call.
-    public func callList<ResponseObject:Mappable>(request: Request) -> Call<[ResponseObject]> {
+    public func callList<ResponseObject:Mappable>(request: Request, encoding: URLEncoding? = nil) -> Call<[ResponseObject]> {
+        
+        var requestPathObject = ""
+        
+        if let urlEncoding = encoding {
+            requestPathObject = request.pathWithQueryParametersWithoutInterpolation()
+        } else {
+            requestPathObject = request.pathWithQueryParameters()
+        }
+        
         let alamofireFunc: (_ executable: Call<[ResponseObject]>) -> Void = { exec in
             Alamofire
-                .request(request.pathWithQueryParameters(), method: request.method, parameters: request.bodyParameters,
-                         encoding: JSONEncoding.default, headers: request.headers)
+                .request(requestPathObject, method: request.method, parameters: request.bodyParameters,
+                         encoding: encoding ?? JSONEncoding.default, headers: request.headers)
                 .responseJSON { dataResponse in
                     
                     switch(dataResponse.result) {

--- a/retrofire/Request.swift
+++ b/retrofire/Request.swift
@@ -59,4 +59,14 @@ public struct Request {
         }
     }
     
+    public func pathWithQueryParametersWithoutInterpolation() -> String {
+        if (queryParameters.count == 0) {
+            return self.path
+        }
+        
+        return queryParameters.reduce("\(self.path)?") { (value, map) in
+            return "\(value)\(map.key)=\(map.value)"
+        }
+    }
+    
 }


### PR DESCRIPTION
Changed encoding parameter to be able to support URLEncoding instead of always using JSONEncoding.

Added pathWithQueryParametersWithoutInterpolation (equal as pathWithQueryParameters) to have the similar behavior, the only difference between a "&" at the end of the string concatenation.